### PR TITLE
docs: Fix a few typos

### DIFF
--- a/data/states/death.py
+++ b/data/states/death.py
@@ -128,7 +128,7 @@ class DeathScene(tools._State):
 
     def make_state_dict(self):
         """
-        Make the dicitonary of state methods for the scene.
+        Make the dictionary of state methods for the scene.
         """
         state_dict = {c.TRANSITION_IN: self.transition_in,
                       c.TRANSITION_OUT: self.transition_out,

--- a/data/states/levels.py
+++ b/data/states/levels.py
@@ -386,7 +386,7 @@ class LevelState(tools._State):
 
     def update_game_data(self):
         """
-        Update the persistant game data dictionary.
+        Update the persistent game data dictionary.
         """
         self.game_data['last location'] = self.player.location
         self.game_data['last direction'] = self.player.direction

--- a/data/states/main_menu.py
+++ b/data/states/main_menu.py
@@ -143,7 +143,7 @@ class Instructions(tools._State):
     def set_next_scene(self):
         """
         Check if there is a saved game. If not, start
-        game at begining.  Otherwise go to load game scene.
+        game at beginning.  Otherwise go to load game scene.
         """
         if not os.path.isfile("save.p"):
             next_scene = c.OVERWORLD

--- a/data/tools.py
+++ b/data/tools.py
@@ -190,7 +190,7 @@ def notify_observers(self, event):
         each_observer.on_notify(event)
 
 def create_game_data_dict():
-    """Create a dictionary of persistant values the player
+    """Create a dictionary of persistent values the player
     carries between states"""
 
     player_items = {'GOLD': dict([('quantity',100),


### PR DESCRIPTION
There are small typos in:
- data/states/death.py
- data/states/levels.py
- data/states/main_menu.py
- data/tools.py

Fixes:
- Should read `persistent` rather than `persistant`.
- Should read `dictionary` rather than `dicitonary`.
- Should read `beginning` rather than `begining`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md